### PR TITLE
feat: 내 서재(LibraryView) 기본 UI 구현

### DIFF
--- a/CiteasyMacDemo/Views/LibraryView.swift
+++ b/CiteasyMacDemo/Views/LibraryView.swift
@@ -105,3 +105,11 @@ private let sampleReferences = [
     LibraryView()
         .frame(width: 600, height: 600)
 }
+
+private let sampleReferences = [
+    (title: "SwiftUI 앱 개발", author: "홍길동 · 2024"),
+    (title: "iOS 비동기 처리", author: "김철수 · 2023"),
+    (title: "애플 생태계와 Swift", author: "이영희 · 2022"),
+    (title: "Combine과 MVVM", author: "박지민 · 2021"),
+    (title: "iPadOS와 멀티태스킹", author: "최윤서 · 2020")
+]

--- a/CiteasyMacDemo/Views/LibraryView.swift
+++ b/CiteasyMacDemo/Views/LibraryView.swift
@@ -8,14 +8,100 @@
 import SwiftUI
 
 struct LibraryView: View {
+    @State private var selectedItems: Set<Int> = []
+
     var body: some View {
-        Text("내 서재 화면")
-            .font(.title)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.blue.opacity(0.05))
+        VStack(alignment: .leading, spacing: 12) {
+            // 1. 타이틀 및 탭
+            HStack {
+                Text("내 서재")
+                    .font(.title2.bold())
+                Spacer()
+                Text("기본")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            // 2. 인용 양식 + 변경
+            HStack(spacing: 4) {
+                Text("사용중인 양식:")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Text("APA 7th")
+                    .foregroundColor(.blue)
+                Button("변경") {}
+                    .font(.footnote)
+            }
+
+            // 3. 필터 및 검색
+            HStack {
+                Picker("필터", selection: .constant(0)) {
+                    Text("최신 북마크순").tag(0)
+                    Text("가나다순").tag(1)
+                }
+                .pickerStyle(MenuPickerStyle())
+
+                Spacer()
+
+                TextField("키워드, 저널, 저자 등으로 검색", text: .constant(""))
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .frame(width: 220)
+            }
+
+            // 4. 전체 선택 + 버튼
+            HStack {
+                Text("전체선택 (0/69)")
+                    .font(.footnote)
+                Spacer()
+                Button(action: {
+                    // 생성 액션
+                }) {
+                    Text("📋 참고문헌 생성")
+                        .font(.subheadline.bold())
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 12)
+                        .background(Color.accentColor)
+                        .foregroundColor(.white)
+                        .cornerRadius(6)
+                }
+            }
+
+            Divider()
+
+            // 5. 참고문헌 리스트
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(0..<5, id: \.self) { index in
+                        ReferenceRowView(
+                            title: sampleReferences[index].title,
+                            author: sampleReferences[index].author,
+                            isSelected: selectedItems.contains(index)
+                        )
+                        .onTapGesture {
+                            if selectedItems.contains(index) {
+                                selectedItems.remove(index)
+                            } else {
+                                selectedItems.insert(index)
+                            }
+                        }
+                        Divider()
+                    }
+                }
+            }
+        }
+        .padding()
     }
 }
 
+private let sampleReferences = [
+    (title: "SwiftUI 앱 개발", author: "홍길동 · 2024"),
+    (title: "iOS 비동기 처리", author: "김철수 · 2023"),
+    (title: "애플 생태계와 Swift", author: "이영희 · 2022"),
+    (title: "Combine과 MVVM", author: "박지민 · 2021"),
+    (title: "iPadOS와 멀티태스킹", author: "최윤서 · 2020")
+]
+
 #Preview {
     LibraryView()
+        .frame(width: 600, height: 600)
 }

--- a/CiteasyMacDemo/Views/MainView.swift
+++ b/CiteasyMacDemo/Views/MainView.swift
@@ -25,29 +25,9 @@ struct MainView: View {
             case .settings:
                 SettingsView()
             }
-
-
-            // → 선택된 탭에 따라 메인 콘텐츠 변경
-//            Group {
-//                switch selectedTab {
-//                case .library:
-//                    ReferenceListView()
-//                case .citationStyle:
-//                    CitationStyleView()
-//                case .settings:
-//                    SettingsView()
-//                case .reload:
-//                    ReloadView()
-//                case .help:
-//                    HelpView()
-//                }
-//            }
-//            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }
-
-
 
 #Preview {
     MainView()

--- a/CiteasyMacDemo/Views/ReferenceRowView.swift
+++ b/CiteasyMacDemo/Views/ReferenceRowView.swift
@@ -1,0 +1,47 @@
+//
+//  ReferenceRowView.swift
+//  CiteasyMacDemo
+//
+//  Created by 김동현 on 3/29/25.
+//
+
+import SwiftUI
+
+struct ReferenceRowView: View {
+    var title: String
+    var author: String
+    var isSelected: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                .foregroundColor(.accentColor)
+                .font(.title3)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundColor(.primary)
+                    .lineLimit(2)
+
+                Text(author)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal)
+        .background(Color.clear)
+    }
+}
+
+#Preview {
+    ReferenceRowView(
+        title: "SwiftUI와 애플 생태계의 발전 방향",
+        author: "홍길동 · 2024",
+        isSelected: false
+    )
+    .frame(width: 480)
+}


### PR DESCRIPTION
## 개요
- 싸이티지(Citeasy) 윈도우 버전의 '내 서재' 화면을 참고하여 기본 UI를 SwiftUI로 구현했습니다.

## 주요 작업 내용
- LibraryView 레이아웃 구성
- 필터 드롭다운 및 검색창 UI 구현
- 참조 문헌 리스트 뷰(ReferenceRowView) 마크업
- 상단 'APA 7th' 텍스트와 '변경' 버튼 구조 반영
- 미리보기, 인용하기 버튼 등은 제외하고 구조만 설계